### PR TITLE
README: format text using new template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
-# pbcopy
-> OSX's pbcopy and pbpaste for Linux
+![][license-badge]
 
-pbcopy paste data from the clipboard to STDOUT.
-pbpaste paste data from the clipboard.
+<div align="center">
+  <a href="http://github.com/fish-shell/oh-my-fish">
+  <img width=90px  src="https://cloud.githubusercontent.com/assets/8317250/8510172/f006f0a4-230f-11e5-98b6-5c2e3c87088f.png">
+  </a>
+</div>
+<br>
+
+# pbcopy
+
+OSX's `pbcopy` and `pbpaste` support for Linux.
+
+## Install
+
+```fish
+$ omf install pbcopy
+```
 
 ## Usage
 
-Copy a list of files in your home directory to the OS X clipboard:
+Copy a list of files in your home directory to the clipboard:
 ```fish
 $ ls ~ | pbcopy
 ```
@@ -16,23 +29,34 @@ Copy the contents of a file to the clipboard:
 $ pbcopy < cookies.txt
 ```
 
-Copy part of a file to the clipboard
+Copy part of a file to the clipboard:
 ```fish
 $ grep 'ip address' serverlist.txt | pbcopy
 ```
 
-Paste from your clipboard to stdout
-echo `pbpaste`
+Paste from your clipboard to stdout:
 ```fish
 $ pbpaste
 ```
 
-Paste from your clipboard to a file
+Paste from your clipboard to a file:
 ```fish
 $ pbpaste > clipboard.txt
 ```
 
-Paste from your clipboard to a file in a remote host
+Paste from your clipboard to a file in a remote host:
 ```fish
 $ pbpaste | ssh username@host 'cat > ~/myclipboard.txt'
 ```
+
+# License
+
+[MIT][mit] © [Oh My Fish!][author] [contributors][contributors]
+
+
+[mit]:            http://opensource.org/licenses/MIT
+[author]:         http://github.com/oh-my-fish
+[contributors]:   https://github.com/oh-my-fish/plugin-pbcopy/graphs/contributors
+[omf-link]:       https://www.github.com/fish-shell/oh-my-fish
+
+[license-badge]:  https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square

--- a/pbcopy.fish
+++ b/pbcopy.fish
@@ -1,7 +1,3 @@
 function pbcopy --description "Copy data from STDIN to the clipboard"
   xsel --clipboard --input
 end
-
-function pbpaste  --description "Paste data from the Clipboard"
-  xsel --clipboard --output
-end

--- a/pbpaste.fish
+++ b/pbpaste.fish
@@ -1,0 +1,3 @@
+function pbpaste  --description "Paste data from the Clipboard"
+  xsel --clipboard --output
+end


### PR DESCRIPTION
Updating the README to new format.
Also fixes a lost `echo`.
